### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/onenKokos/Flight-Prices#readme",
   "dependencies": {
-    "npm": "^6.9.0",
     "tar": ">=4.4.2"
   },
   "devDependencies": {


### PR DESCRIPTION

Hello onenKokos!

It seems like you have npm as one of your (dev-) dependency in Flight-Prices.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
